### PR TITLE
Relax version requirement for ASP.NET

### DIFF
--- a/src/Unity.AspNet.WebApi.csproj
+++ b/src/Unity.AspNet.WebApi.csproj
@@ -30,13 +30,13 @@
   <ItemGroup>
     <Reference Include="System.Web" />
   </ItemGroup>
-  
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TargetFrameworks>net45;net46;net47</TargetFrameworks>
     <DebugType>Portable</DebugType>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <TargetFramework>net47</TargetFramework>
@@ -44,7 +44,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2" />
     <PackageReference Include="WebActivatorEx" Version="2.2.0" />
   </ItemGroup>
 
@@ -61,7 +61,7 @@
     <PackageReference Include="Unity.Container" Version="$(UnityContainerVersion)" />
   </ItemGroup>
 
-  
+
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">
     <DocumentationFile>bin\Release\net45\Unity.AspNet.WebApi.xml</DocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
A project of mine uses version 5.2.6 (not 5.2.7) of this package and API compatibility is just fine. I think requiring a specific patch iteration is too prohibitive. In my case, upgrading to 5.2.7 to fulfill the dependency ended up being a nightmare. It makes much more sense to relax the version requirements.

The situation is that I upgraded to a newer version of the Unity package, which required us to upgrade Unity.AspNet.WebApi, which ended up requiring us to upgrade a bunch of our own ASP.NET packages and the nightmare continued on from there.

Note that my testing was against 5.2.6. However I suspect this will also work for 5.2.0-5.2.5 as well, hence why I dropped the 3rd component.